### PR TITLE
Add client-side Favourites (tags + JSON import/export)

### DIFF
--- a/app/src/App.vue
+++ b/app/src/App.vue
@@ -68,6 +68,21 @@
                     </v-list-item>
                 </router-link>
 
+                <router-link to="/favourites">
+                    <v-list-item @click="0">
+                        <v-list-item-action>
+                            <v-icon medium>
+                                {{ icons.star }}
+                            </v-icon>
+                        </v-list-item-action>
+                        <v-list-item-content>
+                            <v-list-item-title class="navBarEntry">
+                                Favourites
+                            </v-list-item-title>
+                        </v-list-item-content>
+                    </v-list-item>
+                </router-link>
+
                 <router-link to="/settings">
                     <v-list-item @click="0">
                         <v-list-item-action>
@@ -186,6 +201,7 @@ import {
     mdiMenu,
     mdiMicrophone,
     mdiMusicNote,
+    mdiStar,
     // mdiShareVariant,
 } from '@mdi/js';
 import utils from '@/js/utils.js';
@@ -213,6 +229,7 @@ export default {
             menu: mdiMenu,
             microphone: mdiMicrophone,
             musicNote: mdiMusicNote,
+            star: mdiStar,
             // shareVariant: mdiShareVariant,
         },
         isPWA: utils.checkStandalone(),

--- a/app/src/components/FavouriteRow.vue
+++ b/app/src/components/FavouriteRow.vue
@@ -1,0 +1,149 @@
+<template>
+    <div class="favouriteRow d-flex align-center">
+        <v-container
+            v-ripple
+            class="flex-grow-1"
+            @click="favouriteItemClicked"
+        >
+            <v-row class="pt-1 pb-0">
+                <v-col class="py-0">
+                    <h2>{{ name }}</h2>
+                </v-col>
+            </v-row>
+            <v-row class="pb-1 pt-0">
+                <v-col class="py-0 descriptor">
+                    {{ descriptor }}
+                </v-col>
+                <v-col class="py-0 text-right timestamp">
+                    {{ timestampString }}
+                </v-col>
+            </v-row>
+            <!-- Tag chips. @click.stop prevents the row's navigation handler firing. -->
+            <v-row v-if="tags.length > 0" class="pb-2 pt-0" @click.stop>
+                <v-col class="py-0 d-flex flex-wrap align-center" style="gap:4px">
+                    <v-chip
+                        v-for="tag in tags"
+                        :key="tag"
+                        x-small
+                        close
+                        @click:close="$emit('removeTag', { settingID, tag })"
+                    >
+                        {{ tag }}
+                    </v-chip>
+                </v-col>
+            </v-row>
+        </v-container>
+
+        <!-- Add-tag button, outside the clickable container -->
+        <v-menu v-model="addTagMenu" :close-on-content-click="false" offset-y left>
+            <template #activator="{ on }">
+                <v-btn icon @click.stop v-on="on">
+                    <v-icon color="grey darken-1">
+                        {{ icons.tagPlus }}
+                    </v-icon>
+                </v-btn>
+            </template>
+            <v-card width="220" @click.stop>
+                <v-combobox
+                    v-model="tagInputValue"
+                    :items="addableTags"
+                    label="Add tag"
+                    dense
+                    solo
+                    flat
+                    hide-details
+                    class="px-2 pt-1 pb-1"
+                    @change="onTagSelected"
+                    @keydown.esc.stop="addTagMenu = false"
+                />
+            </v-card>
+        </v-menu>
+
+        <v-btn icon class="mr-2" @click.stop="unstar">
+            <v-icon color="amber darken-1">
+                {{ icons.star }}
+            </v-icon>
+        </v-btn>
+    </div>
+</template>
+
+<script>
+import { mdiStar, mdiTagPlusOutline } from '@mdi/js';
+import utils from '@/js/utils';
+
+export default {
+    name: 'FavouriteRow',
+    props: {
+        name: {
+            type: String,
+            required: true
+        },
+        descriptor: {
+            type: String,
+            required: true
+        },
+        settingID: {
+            type: String,
+            required: true
+        },
+        timestamp: {
+            type: Number,
+            required: true
+        },
+        tags: {
+            type: Array,
+            default: () => []
+        },
+        allTags: {
+            type: Array,
+            default: () => []
+        },
+    },
+    data() {
+        return {
+            addTagMenu: false,
+            tagInputValue: null,
+            icons: {
+                star: mdiStar,
+                tagPlus: mdiTagPlusOutline,
+            },
+        };
+    },
+    computed: {
+        timestampString() {
+            return utils.utcToString(this.timestamp);
+        },
+        addableTags() {
+            return this.allTags.filter(t => !this.tags.includes(t));
+        },
+    },
+    methods: {
+        favouriteItemClicked() {
+            this.$emit('favouriteItemClicked', this.settingID);
+        },
+        unstar() {
+            this.$emit('unstar', this.settingID);
+        },
+        onTagSelected(val) {
+            const tag = typeof val === 'string' ? val.trim() : '';
+            if (tag && !this.tags.includes(tag)) {
+                this.$emit('addTag', { settingID: this.settingID, tag });
+            }
+            this.$nextTick(() => {
+                this.tagInputValue = null;
+                this.addTagMenu = false;
+            });
+        },
+    }
+};
+</script>
+
+<style scoped>
+.descriptor {
+  font-style: italic;
+}
+
+.descriptor::first-letter {
+  text-transform: uppercase;
+}
+</style>

--- a/app/src/components/ResultRow.vue
+++ b/app/src/components/ResultRow.vue
@@ -1,43 +1,53 @@
 <template>
-    <router-link
-        :to="{
-            name: 'tune',
-            params: {
-                settingID: settingID,
-                tuneID: setting.tune_id,
-                displayName: displayName,
-            },
-        }"
-    >
-        <v-container
-            v-ripple
-            @click="addToHistory"
+    <div class="resultRow d-flex align-center">
+        <router-link
+            class="flex-grow-1"
+            :to="{
+                name: 'tune',
+                params: {
+                    settingID: settingID,
+                    tuneID: setting.tune_id,
+                    displayName: displayName,
+                },
+            }"
         >
-            <v-row class="pt-1 pb-0">
-                <v-col class="py-0">
-                    <h2>{{ name }}</h2>
-                </v-col>
-            </v-row>
-            <v-row class="pb-2 pt-0">
-                <v-col class="py-0 descriptor">
-                    {{ descriptor }}
-                </v-col>
-                <v-col
-                    v-show="score !== null"
-                    class="py-0 text-right score"
-                    :style="`color: ${scoreColour};`"
-                >
-                    {{ scoreLabel }}
-                </v-col>
-            </v-row>
-        </v-container>
-    </router-link>
+            <v-container
+                v-ripple
+                @click="addToHistory"
+            >
+                <v-row class="pt-1 pb-0">
+                    <v-col class="py-0">
+                        <h2>{{ name }}</h2>
+                    </v-col>
+                </v-row>
+                <v-row class="pb-2 pt-0">
+                    <v-col class="py-0 descriptor">
+                        {{ descriptor }}
+                    </v-col>
+                    <v-col
+                        v-show="score !== null"
+                        class="py-0 text-right score"
+                        :style="`color: ${scoreColour};`"
+                    >
+                        {{ scoreLabel }}
+                    </v-col>
+                </v-row>
+            </v-container>
+        </router-link>
+
+        <v-btn v-if="settingID" icon class="mr-2" @click.stop="toggleFavourite">
+            <v-icon :color="isFav ? 'amber darken-1' : 'grey lighten-1'">
+                {{ isFav ? icons.star : icons.starOutline }}
+            </v-icon>
+        </v-btn>
+    </div>
 </template>
 
 <script>
 import utils from '@/js/utils.js';
 import store from '@/services/store.js';
 import {HistoryItem} from '@/js/schema';
+import {mdiStar, mdiStarOutline} from '@mdi/js';
 
 export default {
     name: 'ResultRow',
@@ -61,7 +71,15 @@ export default {
             required: false
         }
     },
-
+    data() {
+        return {
+            isFav: false,
+            icons: {
+                star: mdiStar,
+                starOutline: mdiStarOutline,
+            },
+        };
+    },
     computed: {
         descriptor: function () {
             return utils.parseDisplayableDescription(this.setting);
@@ -104,6 +122,11 @@ export default {
             return utils.lerpColor(a, b, x);
         },
     },
+    created() {
+        if (this.settingID) {
+            store.isFavourite(this.settingID).then((fav) => { this.isFav = fav; });
+        }
+    },
     methods: {
         addToHistory() {
             store.addToHistory(new HistoryItem({
@@ -111,6 +134,18 @@ export default {
                 setting: this.setting,
                 displayName: this.displayName,
             }));
+        },
+        toggleFavourite() {
+            const result = {
+                settingID: this.settingID,
+                setting: this.setting,
+                displayName: this.displayName,
+            };
+            if (this.isFav) {
+                store.removeFavourite(this.settingID).then(() => { this.isFav = false; });
+            } else {
+                store.addFavourite(result).then(() => { this.isFav = true; });
+            }
         },
     },
 };
@@ -130,12 +165,12 @@ export default {
   font-style: italic;
 }
 
-.resultsTable a {
+.resultRow a {
   text-decoration: none;
   color: inherit;
 }
 
-.resultsTable a div {
+.resultRow a div {
   background: inherit;
 }
 </style>

--- a/app/src/js/schema.js
+++ b/app/src/js/schema.js
@@ -4,3 +4,11 @@ export class HistoryItem {
         this.timestamp = Date.now();
     }
 }
+
+export class FavouriteItem {
+    constructor(result) {
+        this.result = result; // { settingID, setting, displayName }
+        this.timestamp = Date.now();
+        this.tags = []; // string[] — user-defined tags, e.g. ['to practice', 'tuesday session']
+    }
+}

--- a/app/src/router/index.js
+++ b/app/src/router/index.js
@@ -7,6 +7,7 @@ import Results from '@/views/Results.vue';
 import Tune from '@/views/Tune.vue';
 import Settings from '@/views/Settings.vue';
 import History from '@/views/History.vue';
+import Favourites from '@/views/Favourites.vue';
 import Help from '@/views/Help.vue';
 
 Vue.use(VueRouter);
@@ -32,6 +33,10 @@ const routes = [{
     path: '/history',
     name: 'history',
     component: History
+}, {
+    path: '/favourites',
+    name: 'favourites',
+    component: Favourites
 }, {
     path: '/settings',
     name: 'settings',

--- a/app/src/services/store.js
+++ b/app/src/services/store.js
@@ -5,6 +5,7 @@ import eventBus from '@/eventBus.js';
 import {get,
     set
 } from 'idb-keyval';
+import {FavouriteItem} from '@/js/schema';
 import {
     logEvent
 } from 'firebase/analytics';
@@ -35,6 +36,11 @@ class Store {
 
         this.userSettings = JSON.parse(localStorage.getItem('userSettings')) || USER_SETTING_DEFAULTS;
         this.searchState = this.searchStates.READY;
+
+        // Lazily-built set of favourited settingIDs, so the star toggle on
+        // result/tune rows can be drawn without re-reading IndexedDB each time.
+        // Invalidated on any favourites write.
+        this._favouriteIDs = null; // Set<settingID string>
 
         this.analytics = null;
         this.analyticsLoaded = new Promise(resolve => {
@@ -72,6 +78,162 @@ class Store {
         historyItems = historyItems.slice(0, 100);
 
         await set('historyItems', historyItems);
+    }
+
+    // --- Favourites ---------------------------------------------------------
+    // Favourites are stored locally in IndexedDB under 'favouriteItems' as an
+    // array of FavouriteItem objects. settingID is always a string. Each item
+    // carries a `tags` array of user-defined labels.
+
+    async getFavourites() {
+        return await get('favouriteItems') || [];
+    }
+
+    _isValidSettingID(settingID) {
+        const s = String(settingID);
+        return settingID != null && s !== 'undefined' && s !== 'null' && s !== '';
+    }
+
+    async _loadFavouriteIDs() {
+        if (this._favouriteIDs === null) {
+            const items = await this.getFavourites();
+            this._favouriteIDs = new Set(items.map(f => String(f.result.settingID)));
+        }
+        return this._favouriteIDs;
+    }
+
+    async _saveFavourites(items) {
+        await set('favouriteItems', items);
+        this._favouriteIDs = null; // invalidate cache
+    }
+
+    async addFavourite(result) {
+        if (!this._isValidSettingID(result.settingID)) {
+            console.warn('addFavourite: invalid settingID, ignoring', result.settingID);
+            return;
+        }
+        result = { ...result, settingID: String(result.settingID) };
+        const ids = await this._loadFavouriteIDs();
+        if (!ids.has(result.settingID)) {
+            const items = await this.getFavourites();
+            items.unshift(new FavouriteItem(result));
+            await this._saveFavourites(items);
+        }
+    }
+
+    async removeFavourite(settingID) {
+        settingID = String(settingID);
+        const items = (await this.getFavourites()).filter(f => String(f.result.settingID) !== settingID);
+        await this._saveFavourites(items);
+    }
+
+    async isFavourite(settingID) {
+        if (!this._isValidSettingID(settingID)) return false;
+        const ids = await this._loadFavouriteIDs();
+        return ids.has(String(settingID));
+    }
+
+    // --- Tags ---------------------------------------------------------------
+
+    async addTagToFavourite(settingID, tag) {
+        settingID = String(settingID);
+        tag = tag.trim();
+        if (!tag) return;
+        const items = await this.getFavourites();
+        const item = items.find(f => String(f.result.settingID) === settingID);
+        if (item) {
+            if (!item.tags) item.tags = [];
+            if (!item.tags.includes(tag)) item.tags.push(tag);
+            await this._saveFavourites(items);
+        }
+    }
+
+    async removeTagFromFavourite(settingID, tag) {
+        settingID = String(settingID);
+        const items = await this.getFavourites();
+        const item = items.find(f => String(f.result.settingID) === settingID);
+        if (item && item.tags) {
+            item.tags = item.tags.filter(t => t !== tag);
+            await this._saveFavourites(items);
+        }
+    }
+
+    async renameTag(oldName, newName) {
+        newName = newName.trim();
+        if (!newName || oldName === newName) return;
+        const items = await this.getFavourites();
+        items.forEach(item => {
+            if (item.tags && item.tags.includes(oldName)) {
+                item.tags = item.tags.map(t => (t === oldName ? newName : t));
+            }
+        });
+        await this._saveFavourites(items);
+    }
+
+    async deleteTag(name) {
+        const items = await this.getFavourites();
+        items.forEach(item => {
+            if (item.tags) item.tags = item.tags.filter(t => t !== name);
+        });
+        await this._saveFavourites(items);
+    }
+
+    // --- Import / export ----------------------------------------------------
+    // A simple, self-describing JSON document for favourites only, so users can
+    // back up and move their favourites between devices/browsers without a
+    // server. Import merges (it never clears existing favourites), unioning tags
+    // for settings that are already favourited.
+
+    async exportFavourites() {
+        const payload = {
+            type: 'folkfriend-favourites',
+            version: 1,
+            exportedAt: Date.now(),
+            favouriteItems: await this.getFavourites(),
+        };
+        return JSON.stringify(payload, null, 2);
+    }
+
+    async importFavourites(jsonString) {
+        let payload;
+        try {
+            payload = JSON.parse(jsonString);
+        } catch (e) {
+            throw new Error('Could not read file: it is not valid JSON.');
+        }
+        const incoming = Array.isArray(payload) ? payload : payload.favouriteItems;
+        if (!Array.isArray(incoming)) {
+            throw new Error('This file does not contain any favourites.');
+        }
+
+        const items = await this.getFavourites();
+        const bySettingID = new Map(items.map(f => [String(f.result.settingID), f]));
+        let added = 0;
+        let updated = 0;
+
+        for (const raw of incoming) {
+            if (!raw || !raw.result || !this._isValidSettingID(raw.result.settingID)) continue;
+            const settingID = String(raw.result.settingID);
+            const tags = Array.isArray(raw.tags) ? raw.tags.filter(t => typeof t === 'string') : [];
+            const existing = bySettingID.get(settingID);
+            if (existing) {
+                // Union tags onto the favourite we already have.
+                if (!existing.tags) existing.tags = [];
+                let changed = false;
+                tags.forEach(t => { if (!existing.tags.includes(t)) { existing.tags.push(t); changed = true; } });
+                if (changed) updated++;
+            } else {
+                const item = new FavouriteItem({ ...raw.result, settingID });
+                if (typeof raw.timestamp === 'number') item.timestamp = raw.timestamp;
+                item.tags = tags;
+                items.push(item);
+                bySettingID.set(settingID, item);
+                added++;
+            }
+        }
+
+        await this._saveFavourites(items);
+        return { added, updated };
     }
 
     loadAnalytics(analytics) {

--- a/app/src/views/Favourites.vue
+++ b/app/src/views/Favourites.vue
@@ -1,0 +1,327 @@
+<template>
+    <v-container class="viewContainerWrapper">
+        <div class="d-flex align-center my-2">
+            <h1>Favourites</h1>
+            <v-spacer />
+            <v-select
+                v-model="sortBy"
+                :items="sortOptions"
+                dense
+                hide-details
+                style="max-width: 120px;"
+                class="mr-2 caption"
+                :prepend-icon="icons.sort"
+            />
+            <v-btn icon small title="Export favourites" :disabled="favouriteItems.length === 0" @click="exportFavourites">
+                <v-icon small>{{ icons.export }}</v-icon>
+            </v-btn>
+            <v-btn icon small title="Import favourites" @click="triggerImport">
+                <v-icon small>{{ icons.import }}</v-icon>
+            </v-btn>
+            <input ref="importInput" type="file" accept="application/json,.json" class="d-none" @change="onImportFileChosen">
+        </div>
+
+        <!-- Tag filter bar -->
+        <div v-if="allTags.length > 0" class="tag-filter-bar mb-3">
+            <div class="d-flex flex-wrap align-center" style="gap:6px">
+                <span class="caption grey--text mr-1">Filter:</span>
+                <v-chip
+                    v-for="tag in allTags"
+                    :key="tag"
+                    small
+                    :color="activeTags.includes(tag) ? 'primary' : undefined"
+                    :outlined="!activeTags.includes(tag)"
+                    @click="toggleActiveTag(tag)"
+                >
+                    {{ tag }}
+                </v-chip>
+                <v-btn v-if="activeTags.length > 0" x-small text @click="activeTags = []">Clear</v-btn>
+                <v-spacer />
+                <v-btn x-small text color="grey" @click="manageTagsDialog = true">Manage tags</v-btn>
+            </div>
+        </div>
+
+        <v-list v-if="visibleItems.length > 0" class="resultsTable">
+            <FavouriteRow
+                v-for="item in visibleItems"
+                :key="item.result.settingID"
+                :name="parseName(item)"
+                :descriptor="parseDescriptor(item)"
+                :setting-i-d="item.result.settingID"
+                :timestamp="item.timestamp"
+                :tags="item.tags || []"
+                :all-tags="allTags"
+                @favouriteItemClicked="loadFavouriteItem"
+                @unstar="removeFavourite"
+                @addTag="addTag"
+                @removeTag="removeTag"
+            />
+        </v-list>
+
+        <p v-else-if="favouriteItems.length > 0" class="mt-4 grey--text">
+            No favourites match the selected tags.
+        </p>
+        <p v-else class="mt-4 grey--text">
+            No favourites yet. Star a tune from the results list to save it here.
+        </p>
+
+        <v-snackbar v-model="snackbar" :timeout="4000">{{ snackbarText }}</v-snackbar>
+
+        <!-- Manage tags dialog -->
+        <v-dialog v-model="manageTagsDialog" max-width="360">
+            <v-card>
+                <v-card-title>Manage tags</v-card-title>
+                <v-list dense>
+                    <v-list-item v-for="tag in allTags" :key="tag">
+                        <v-list-item-content>
+                            <v-list-item-title>{{ tag }}</v-list-item-title>
+                        </v-list-item-content>
+                        <v-list-item-action class="flex-row" style="gap:4px">
+                            <v-btn icon x-small @click="openRenameTag(tag)">
+                                <v-icon x-small>{{ icons.pencil }}</v-icon>
+                            </v-btn>
+                            <v-btn icon x-small color="red" @click="confirmDeleteTag(tag)">
+                                <v-icon x-small>{{ icons.delete }}</v-icon>
+                            </v-btn>
+                        </v-list-item-action>
+                    </v-list-item>
+                    <v-list-item v-if="allTags.length === 0">
+                        <v-list-item-content class="grey--text">No tags yet.</v-list-item-content>
+                    </v-list-item>
+                </v-list>
+                <v-card-actions>
+                    <v-spacer />
+                    <v-btn text @click="manageTagsDialog = false">Close</v-btn>
+                </v-card-actions>
+            </v-card>
+        </v-dialog>
+
+        <!-- Rename tag dialog -->
+        <v-dialog v-model="renameTagDialog" max-width="320">
+            <v-card>
+                <v-card-title>Rename tag</v-card-title>
+                <v-card-text>
+                    <v-text-field
+                        v-model="renameTagNew"
+                        label="New name"
+                        autofocus
+                        @keydown.enter="commitRenameTag"
+                        @keydown.esc="renameTagDialog = false"
+                    />
+                </v-card-text>
+                <v-card-actions>
+                    <v-spacer />
+                    <v-btn text @click="renameTagDialog = false">Cancel</v-btn>
+                    <v-btn color="primary" text :disabled="!renameTagNew.trim()" @click="commitRenameTag">Rename</v-btn>
+                </v-card-actions>
+            </v-card>
+        </v-dialog>
+
+        <!-- Delete tag confirm dialog -->
+        <v-dialog v-model="deleteTagDialog" max-width="320">
+            <v-card>
+                <v-card-title>Delete tag?</v-card-title>
+                <v-card-text>
+                    "{{ deleteTagTarget }}" will be removed from all favourites.
+                </v-card-text>
+                <v-card-actions>
+                    <v-spacer />
+                    <v-btn text @click="deleteTagDialog = false">Cancel</v-btn>
+                    <v-btn color="red" text @click="doDeleteTag">Delete</v-btn>
+                </v-card-actions>
+            </v-card>
+        </v-dialog>
+    </v-container>
+</template>
+
+<script>
+import { mdiExport, mdiImport, mdiPencil, mdiDelete, mdiSort } from '@mdi/js';
+import eventBus from '@/eventBus';
+import store from '@/services/store';
+import FavouriteRow from '@/components/FavouriteRow';
+import utils from '@/js/utils';
+import router from '@/router/index.js';
+
+export default {
+    name: 'FavouritesView',
+    components: { FavouriteRow },
+    data() {
+        return {
+            favouriteItems: [],
+            activeTags: [],
+            manageTagsDialog: false,
+            renameTagDialog: false,
+            renameTagOld: '',
+            renameTagNew: '',
+            deleteTagDialog: false,
+            deleteTagTarget: null,
+            snackbar: false,
+            snackbarText: '',
+            sortBy: 'date',
+            sortOptions: [
+                { text: 'Date', value: 'date' },
+                { text: 'Name', value: 'name' },
+            ],
+            icons: {
+                export: mdiExport,
+                import: mdiImport,
+                pencil: mdiPencil,
+                delete: mdiDelete,
+                sort: mdiSort,
+            },
+        };
+    },
+    computed: {
+        allTags() {
+            const tags = new Set();
+            this.favouriteItems.forEach(item => (item.tags || []).forEach(t => tags.add(t)));
+            return [...tags].sort();
+        },
+        visibleItems() {
+            const filtered = this.favouriteItems.filter(item =>
+                this.activeTags.length === 0 ||
+                this.activeTags.every(t => (item.tags || []).includes(t))
+            );
+            const sorted = [...filtered];
+            if (this.sortBy === 'name') {
+                sorted.sort((a, b) => this.parseName(a).localeCompare(this.parseName(b)));
+            } else {
+                sorted.sort((a, b) => b.timestamp - a.timestamp);
+            }
+            return sorted;
+        },
+    },
+    created() {
+        eventBus.$emit('parentViewActivated');
+        this.loadFavourites();
+    },
+    methods: {
+        parseName(item) {
+            return utils.parseDisplayableName(item.result.displayName);
+        },
+        parseDescriptor(item) {
+            return utils.parseDisplayableDescription(item.result.setting);
+        },
+        loadFavourites() {
+            store.getFavourites().then(items => {
+                this.favouriteItems = items;
+                // Drop any active filter tags that no longer exist.
+                const tagSet = new Set();
+                items.forEach(i => (i.tags || []).forEach(t => tagSet.add(t)));
+                this.activeTags = this.activeTags.filter(t => tagSet.has(t));
+            });
+        },
+        toggleActiveTag(tag) {
+            const i = this.activeTags.indexOf(tag);
+            if (i >= 0) this.activeTags.splice(i, 1);
+            else this.activeTags.push(tag);
+        },
+        loadFavouriteItem(settingID) {
+            const item = this.favouriteItems.find(f => f.result.settingID === settingID);
+            if (item) {
+                router.push({
+                    name: 'tune',
+                    params: {
+                        tuneID: item.result.setting.tune_id,
+                        settingID: item.result.settingID,
+                        displayName: item.result.displayName,
+                    }
+                });
+                eventBus.$emit('childViewActivated');
+            }
+        },
+        removeFavourite(settingID) {
+            store.removeFavourite(settingID).then(() => this.loadFavourites());
+        },
+        addTag({ settingID, tag }) {
+            store.addTagToFavourite(settingID, tag).then(() => this.loadFavourites());
+        },
+        removeTag({ settingID, tag }) {
+            store.removeTagFromFavourite(settingID, tag).then(() => this.loadFavourites());
+        },
+        openRenameTag(tag) {
+            this.renameTagOld = tag;
+            this.renameTagNew = tag;
+            this.manageTagsDialog = false;
+            this.renameTagDialog = true;
+        },
+        commitRenameTag() {
+            const newName = this.renameTagNew.trim();
+            if (!newName) { this.renameTagDialog = false; return; }
+            store.renameTag(this.renameTagOld, newName).then(() => {
+                const i = this.activeTags.indexOf(this.renameTagOld);
+                if (i >= 0) this.activeTags.splice(i, 1, newName);
+                this.renameTagDialog = false;
+                this.loadFavourites();
+            });
+        },
+        confirmDeleteTag(tag) {
+            this.deleteTagTarget = tag;
+            this.manageTagsDialog = false;
+            this.deleteTagDialog = true;
+        },
+        doDeleteTag() {
+            store.deleteTag(this.deleteTagTarget).then(() => {
+                const i = this.activeTags.indexOf(this.deleteTagTarget);
+                if (i >= 0) this.activeTags.splice(i, 1);
+                this.deleteTagDialog = false;
+                this.deleteTagTarget = null;
+                this.loadFavourites();
+            });
+        },
+        async exportFavourites() {
+            const json = await store.exportFavourites();
+            const blob = new Blob([json], { type: 'application/json' });
+            const url = URL.createObjectURL(blob);
+            const a = document.createElement('a');
+            a.href = url;
+            a.download = 'folkfriend-favourites.json';
+            a.click();
+            URL.revokeObjectURL(url);
+        },
+        triggerImport() {
+            this.$refs.importInput.click();
+        },
+        onImportFileChosen(event) {
+            const file = event.target.files && event.target.files[0];
+            // Reset so choosing the same file again re-triggers change.
+            event.target.value = '';
+            if (!file) return;
+            const reader = new FileReader();
+            reader.onload = () => {
+                store.importFavourites(reader.result)
+                    .then(({ added, updated }) => {
+                        this.loadFavourites();
+                        this.snackbarText = `Imported ${added} new favourite${added === 1 ? '' : 's'}` +
+                            (updated > 0 ? `, updated tags on ${updated}.` : '.');
+                        this.snackbar = true;
+                    })
+                    .catch(err => {
+                        this.snackbarText = err.message || 'Import failed.';
+                        this.snackbar = true;
+                    });
+            };
+            reader.readAsText(file);
+        },
+    }
+};
+</script>
+
+<style scoped>
+.resultsTable > div:nth-child(odd) {
+    background: #efefef;
+}
+
+.descriptor {
+  font-style: italic;
+}
+
+.tag-filter-bar {
+    border-bottom: 1px solid #e0e0e0;
+    padding-bottom: 10px;
+}
+
+.timestamp {
+    white-space: nowrap;
+}
+</style>

--- a/app/src/views/Results.vue
+++ b/app/src/views/Results.vue
@@ -50,7 +50,7 @@ export default {
     max-width: min(90vh, 90vw);
 }
 
-.resultsTable > a:nth-child(odd) {
+.resultsTable > div:nth-child(odd) {
     background: #efefef;
 }
 

--- a/app/src/views/Tune.vue
+++ b/app/src/views/Tune.vue
@@ -36,9 +36,16 @@
                             )}`
                         }}
                     </h3>
-                    <v-icon v-if="settingData.hasChords" class="justify-end tabChordIcon">
-                        $vuetify.icons.tabChord
-                    </v-icon>
+                    <div class="d-flex justify-end align-center settingHeaderActions">
+                        <v-btn icon small @click.stop="toggleFavourite(settingData)">
+                            <v-icon small :color="isFavourite(settingData) ? 'amber darken-1' : 'grey lighten-1'">
+                                {{ isFavourite(settingData) ? icons.star : icons.starOutline }}
+                            </v-icon>
+                        </v-btn>
+                        <v-icon v-if="settingData.hasChords" class="tabChordIcon">
+                            $vuetify.icons.tabChord
+                        </v-icon>
+                    </div>
                 </v-expansion-panel-header>
                 <v-expansion-panel-content>
                     <AbcDisplay :abc="settingData.abc" :mode="settingData.mode" :meter="settingData.meter"
@@ -60,10 +67,13 @@
 import utils from '@/js/utils.js';
 import AbcDisplay from '@/components/AbcDisplay';
 import ffBackend from '@/services/backend.js';
+import store from '@/services/store.js';
 import eventBus from '@/eventBus';
 
 import {
     mdiOpenInNew,
+    mdiStar,
+    mdiStarOutline,
 } from '@mdi/js';
 export default {
     name: 'TuneView',
@@ -94,9 +104,12 @@ export default {
 
             expandedIndex: [],
 
+            favSettingIDs: [],
+
             icons: {
                 openInNew: mdiOpenInNew,
-
+                star: mdiStar,
+                starOutline: mdiStarOutline,
             },
             sourceTheSession: `https://thesession.org/tunes/${this.tuneID}`
         };
@@ -119,6 +132,13 @@ export default {
             settingData.hasChords = (Math.random() > 0.5);
             return settingData;
         })
+
+        // Note which settings are already favourited so we can show filled stars.
+        for (const settingData of this.settings) {
+            if (await store.isFavourite(settingData.setting_id)) {
+                this.favSettingIDs.push(String(settingData.setting_id));
+            }
+        }
 
         let primaryAliasIndex = 0;
 
@@ -177,7 +197,26 @@ export default {
         },
         sourceClicked: function () {
             window.open(this.sourceTheSession);
-        }
+        },
+        isFavourite: function (settingData) {
+            return this.favSettingIDs.includes(String(settingData.setting_id));
+        },
+        toggleFavourite: function (settingData) {
+            const settingID = String(settingData.setting_id);
+            if (this.isFavourite(settingData)) {
+                store.removeFavourite(settingID).then(() => {
+                    this.favSettingIDs = this.favSettingIDs.filter(id => id !== settingID);
+                });
+            } else {
+                store.addFavourite({
+                    settingID,
+                    setting: settingData,
+                    displayName: this.name,
+                }).then(() => {
+                    this.favSettingIDs.push(settingID);
+                });
+            }
+        },
     },
 };
 </script>


### PR DESCRIPTION
Hi,

Here is a somewhat more complex MR, a feature that I use personally alot in the beta testing - favourites. I have added tags as well, used like "practicing" or which context they are played etc. Very useful imho. Relates to https://github.com/TomWyllie/folkfriend/pull/55


I will also as a second step make a MR for the firebase sync of favourites.

Greetings


AI Description:

## Favourites (client-side, with tags + import/export)

This is the **Favourites** feature split out into its own focused PR, as you suggested when closing the earlier combined one. I've reworked it from my fork to address your review points rather than porting it verbatim.

### What it does

- **Star/unstar** a setting from the results list and from the tune view.
- **Favourites view**: list of starred settings, filter by tag, sort by date or name, click a row to open the tune.
- **Tags**: user-defined labels per favourite — add/remove inline on a row, rename/delete via a small "Manage tags" dialog.
- **JSON export/import** of favourites, so users can back them up and move them between devices/browsers without a server.

### Design decisions (responding to your comments)

- **Entirely client-side, no backend/sync.** Favourites live in IndexedDB only (under `favouriteItems`). I agree a proper backend is a separate piece of work — this PR doesn't presume one. To address the data-loss concern you raised, **import/export is the safety net**: users can export their favourites to a JSON file and re-import them anywhere. Import **merges** (it unions tags onto already-favourited settings and never clears existing favourites).
- **No dynamically-generated HTML page.** The old "share as HTML" export (and the in-component HTML string building) is gone. Export is a single, plain, self-describing JSON document.
- **Kept it small.** I deliberately dropped the heavier UI from my fork (group-by-tag/date, bulk select + bulk tag, per-row ABC previews, filter persistence) to stay close to the existing simple row style. Tags are in because they're cheap on top of the data model and genuinely useful, but the surface area is intentionally minimal. The store exposes only the methods the UI actually uses (no dead API).
- **Not included on purpose:** no Firebase/Firestore sync, no Workbox config changes, no Rust/`Cargo` changes, no changes to `soup_dragon.wav` or any benchmark/scores. This PR is app-only.

### Files

| File | Change |
|------|--------|
| `app/src/js/schema.js` | `FavouriteItem` class (with `tags`) |
| `app/src/services/store.js` | Favourites + tags CRUD, favourites-only JSON export/import |
| `app/src/views/Favourites.vue` | New view: list, tag filter, sort, manage-tags, import/export |
| `app/src/components/FavouriteRow.vue` | New row component |
| `app/src/components/ResultRow.vue` | Star toggle (root `<a>` → flex `<div>` so the star sits outside the nav link) |
| `app/src/views/Results.vue` | Row striping selector updated `a` → `div` to match |
| `app/src/views/Tune.vue` | Per-setting star in each expansion-panel header |
| `app/src/router/index.js`, `app/src/App.vue` | `/favourites` route + nav entry |

### Notes for the data model

- `settingID` is always stored as a string.
- Each favourite is `{ result: { settingID, setting, displayName }, timestamp, tags: [] }`.
- The store keeps a lazily-built `Set` of favourited setting IDs so the star toggle on result/tune rows can render without re-reading IndexedDB each time; it's invalidated on any write.

### Testing

- `npm run build` passes (only the pre-existing asset-size warnings).
- Verified manually: starring from results and from the tune view, tag add/remove/rename/delete, tag filtering, and a JSON export → import round-trip (including the merge behaviour).

Happy to adjust scope, naming, or copy — and to drop tags into a follow-up PR if you'd prefer the very first cut to be just star/unstar + list + import/export.
