### PR TITLE
Tempo slider + loop for tune playback (seamless tempo change)

### DIFF
--- a/app/src/components/AbcDisplay.vue
+++ b/app/src/components/AbcDisplay.vue
@@ -162,9 +162,11 @@ export default {
                 this.midiBuffer.resume();
             } else {
                 this.paused = true;
-                // ABCJS pause() fires onEnded — clear it so loop mode doesn't
-                // restart playback when the user only wanted to pause.
-                this.midiBuffer.onEnded = null;
+                // ABCJS fires onEnded when pause() stops the audio source, and
+                // its end-callback calls onEnded() unconditionally — so swap in
+                // a no-op (not null, which would throw) to suppress the loop
+                // restart while the user is only pausing.
+                this.midiBuffer.onEnded = () => {};
                 this.midiBuffer.pause();
             }
         },
@@ -247,7 +249,9 @@ export default {
                 // same place in the tune rather than the same wall-clock time.
                 let positionBeats = 0;
                 if (this.midiBuffer) {
-                    this.midiBuffer.onEnded = null;
+                    // No-op rather than null: pause() triggers the old synth's
+                    // end-callback, which calls onEnded() unconditionally.
+                    this.midiBuffer.onEnded = () => {};
                     const positionSeconds = this.midiBuffer.pause();
                     const oldMsPerMeasure = this.midiBuffer.millisecondsPerMeasure;
                     const oldBeatsPerMeasure = this.midiBuffer.beatsPerMeasure;
@@ -275,9 +279,10 @@ export default {
         stopPlaying: function () {
             this.paused = true;
             if (this.midiBuffer) {
-                // ABCJS stop() fires onEnded — clear it so loop mode doesn't
-                // restart, and null the buffer ourselves.
-                this.midiBuffer.onEnded = null;
+                // ABCJS stop() fires the end-callback, which calls onEnded()
+                // unconditionally — swap in a no-op (not null, which would
+                // throw) so loop mode doesn't restart, then null the buffer.
+                this.midiBuffer.onEnded = () => {};
                 this.midiBuffer.stop();
                 this.midiBuffer = null;
             }

--- a/app/src/components/AbcDisplay.vue
+++ b/app/src/components/AbcDisplay.vue
@@ -21,35 +21,47 @@
             class="py-2"
         >
             <v-btn
-                class="mx-1 px-3 abcControls"
+                class="mx-1 px-2 abcControls"
                 @click="playButton"
             >
-                <v-icon v-if="paused">
+                <v-icon
+                    v-if="paused"
+                    :size="18"
+                >
                     {{ icons.play }}
                 </v-icon>
-                <v-icon v-else>
+                <v-icon
+                    v-else
+                    :size="18"
+                >
                     {{ icons.pause }}
                 </v-icon>
             </v-btn>
             <v-btn
-                class="mx-1 px-3 abcControls"
+                class="mx-1 px-2 abcControls"
                 :color="looping ? 'primary' : ''"
                 :title="looping ? 'Loop on' : 'Loop off'"
                 @click="looping = !looping"
             >
-                <v-icon>{{ icons.repeat }}</v-icon>
+                <v-icon :size="18">
+                    {{ icons.repeat }}
+                </v-icon>
             </v-btn>
             <v-btn
-                class="mx-1 px-3 abcControls"
+                class="mx-1 px-2 abcControls"
                 @click="stopPlaying"
             >
-                <v-icon>{{ icons.stop }}</v-icon>
+                <v-icon :size="18">
+                    {{ icons.stop }}
+                </v-icon>
             </v-btn>
             <v-btn
-                class="mx-1 px-3 abcControls"
+                class="mx-1 px-2 abcControls"
                 @click="goFullScreen"
             >
-                <v-icon>{{ icons.fullscreen }}</v-icon>
+                <v-icon :size="18">
+                    {{ icons.fullscreen }}
+                </v-icon>
             </v-btn>
         </v-row>
         <v-row
@@ -326,7 +338,9 @@ export default {
 }
 
 .abcControls {
+    /* 25% smaller than the default 36px v-btn (icons sized to 18px inline). */
     min-width: 0 !important;
+    height: 27px !important;
 }
 
 .tempoRow {

--- a/app/src/components/AbcDisplay.vue
+++ b/app/src/components/AbcDisplay.vue
@@ -17,14 +17,9 @@
         <v-row
             wrap
             justify="center"
+            align="center"
             class="py-2"
         >
-            <!-- <v-btn
-                class="mx-1 px-3 abcControls"
-                @click="restartPlaying"
-            >
-                <v-icon>{{ icons.replay }}</v-icon>
-            </v-btn> -->
             <v-btn
                 class="mx-1 px-3 abcControls"
                 @click="playButton"
@@ -35,6 +30,14 @@
                 <v-icon v-else>
                     {{ icons.pause }}
                 </v-icon>
+            </v-btn>
+            <v-btn
+                class="mx-1 px-3 abcControls"
+                :color="looping ? 'primary' : ''"
+                :title="looping ? 'Loop on' : 'Loop off'"
+                @click="looping = !looping"
+            >
+                <v-icon>{{ icons.repeat }}</v-icon>
             </v-btn>
             <v-btn
                 class="mx-1 px-3 abcControls"
@@ -49,11 +52,34 @@
                 <v-icon>{{ icons.fullscreen }}</v-icon>
             </v-btn>
         </v-row>
+        <v-row
+            justify="center"
+            align="center"
+            class="pb-2 px-6 tempoRow"
+        >
+            <v-icon
+                small
+                class="mr-2"
+            >
+                {{ icons.metronome }}
+            </v-icon>
+            <v-slider
+                v-model="tempoPercent"
+                min="25"
+                max="200"
+                step="5"
+                hide-details
+                dense
+                class="tempoSlider"
+                @change="tempoChanged"
+            />
+            <span class="ml-2 tempoLabel">{{ tempoPercent }}%</span>
+        </v-row>
     </v-card>
 </template>
 
 <script>
-import { mdiArrowExpand, mdiPause, mdiPlay, mdiStop } from '@mdi/js';
+import { mdiArrowExpand, mdiMetronome, mdiPause, mdiPlay, mdiRepeat, mdiStop } from '@mdi/js';
 import store from '@/services/store.js';
 import ABCJS from 'abcjs';
 import eventBus from '@/eventBus';
@@ -80,13 +106,18 @@ export default {
         return {
             abcVisual: null,
             midiBuffer: null,
+            audioContext: null,
             paused: true,
             fullscreen: false,
+            tempoPercent: 100,
+            looping: false,
 
             icons: {
                 fullscreen: mdiArrowExpand,
+                metronome: mdiMetronome,
                 pause: mdiPause,
                 play: mdiPlay,
+                repeat: mdiRepeat,
                 stop: mdiStop,
             },
         };
@@ -110,12 +141,11 @@ export default {
     mounted: async function () {
         const abcJsWrapperDiv = this.$el.childNodes[1];
         const svgDiv = abcJsWrapperDiv.firstChild;
-        const midDiv = abcJsWrapperDiv.lastChild;
 
         this.abcVisual = ABCJS.renderAbc(svgDiv, this.abcText, { responsive: 'resize' })[0];
         this.$emit('abcRendered');
 
-        eventBus.$on("stopSynthPlayback", () => {
+        eventBus.$on('stopSynthPlayback', () => {
             this.stopPlaying();
             delete this.midiBuffer;
         });
@@ -126,9 +156,15 @@ export default {
                 this.startPlaying();
             } else if(this.paused) {
                 this.paused = false;
+                // Restore the onEnded handler that pause() cleared, so a
+                // natural end still triggers a loop restart.
+                this.midiBuffer.onEnded = () => this.handlePlaybackEnded();
                 this.midiBuffer.resume();
             } else {
                 this.paused = true;
+                // ABCJS pause() fires onEnded — clear it so loop mode doesn't
+                // restart playback when the user only wanted to pause.
+                this.midiBuffer.onEnded = null;
                 this.midiBuffer.pause();
             }
         },
@@ -136,51 +172,114 @@ export default {
             this.paused = false;
 
             if (!ABCJS.synth.supportsAudio()) {
-                console.error("ABCJS doesn't support audio synth");
+                console.error('ABCJS doesn\'t support audio synth');
                 return;
             }
 
-            // Can create an AudioContext here because are inside the context of a button press
+            // Can create an AudioContext here because we are inside the context of a button press
             window.AudioContext = window.AudioContext ||
-                            window.webkitAudioContext ||
-                            navigator.mozAudioContext ||
-                            navigator.msAudioContext;
+                window.webkitAudioContext ||
+                navigator.mozAudioContext ||
+                navigator.msAudioContext;
 
-            let audioContext = new window.AudioContext();
+            // Reuse a single AudioContext across plays — iOS disallows creating
+            // multiple contexts, and the seamless tempo change below primes a
+            // second synth on the same context.
+            if (!this.audioContext) {
+                this.audioContext = new window.AudioContext();
+            }
 
-            audioContext.resume().then(() => {
+            this.audioContext.resume().then(() => {
                 // In theory the AC shouldn't start suspended because it is being initialized in a click handler, but iOS seems to anyway.
 
                 // This does a bare minimum so this object could be created in advance, or whenever convenient.
                 this.midiBuffer = new ABCJS.synth.CreateSynth();
 
+                // Scale the measure duration by the tempo slider: 100% plays at
+                // the tune's notated tempo, lower is slower, higher is faster.
+                const millisecondsPerMeasure = this.abcVisual.millisecondsPerMeasure() * (100 / this.tempoPercent);
+
                 // midiBuffer.init preloads and caches all the notes needed. There may be significant network traffic here.
                 return this.midiBuffer.init({
                     visualObj: this.abcVisual,
-                    audioContext: audioContext,
-                    millisecondsPerMeasure: this.abcVisual.millisecondsPerMeasure()
-                }).then(response => {
+                    audioContext: this.audioContext,
+                    millisecondsPerMeasure,
+                    // onEnded must be nested under options.options — ABCJS reads
+                    // it as params = options.options and then params.onEnded.
+                    options: {
+                        onEnded: () => this.handlePlaybackEnded(),
+                    },
+                }).then(() => {
                     // midiBuffer.prime actually builds the output buffer.
                     return this.midiBuffer.prime();
-                }).then(response => {
+                }).then(() => {
                     // At this point, everything slow has happened. midiBuffer.start will return very quickly and will start playing very quickly without lag.
                     this.midiBuffer.start();
-                    this.midiBuffer.onEnded = () => {
-                        if(!this.paused) {
-                            this.stopPlaying();
-                        }
-                    };
                     return Promise.resolve();
                 }).catch(error => {
-                    console.error("AudioContext error", error);
-                })
+                    console.error('AudioContext error', error);
+                });
             });
+        },
+        tempoChanged: function () {
+            // Nothing playing — the new tempo is picked up on the next play.
+            if (this.paused || !this.midiBuffer) {
+                return;
+            }
+
+            // Prime a fresh synth at the new tempo in the background while the
+            // current one keeps playing, then swap them at the same musical
+            // position so the tempo change is seamless (no audible gap).
+            const millisecondsPerMeasure = this.abcVisual.millisecondsPerMeasure() * (100 / this.tempoPercent);
+            const newBuffer = new ABCJS.synth.CreateSynth();
+            newBuffer.init({
+                visualObj: this.abcVisual,
+                audioContext: this.audioContext,
+                millisecondsPerMeasure,
+                options: {
+                    onEnded: () => this.handlePlaybackEnded(),
+                },
+            }).then(() => {
+                return newBuffer.prime();
+            }).then(() => {
+                // pause() returns the elapsed playback time in seconds at the
+                // OLD tempo. Convert it to beats so the new synth resumes at the
+                // same place in the tune rather than the same wall-clock time.
+                let positionBeats = 0;
+                if (this.midiBuffer) {
+                    this.midiBuffer.onEnded = null;
+                    const positionSeconds = this.midiBuffer.pause();
+                    const oldMsPerMeasure = this.midiBuffer.millisecondsPerMeasure;
+                    const oldBeatsPerMeasure = this.midiBuffer.beatsPerMeasure;
+                    if (positionSeconds && oldMsPerMeasure && oldBeatsPerMeasure) {
+                        positionBeats = positionSeconds * 1000 * oldBeatsPerMeasure / oldMsPerMeasure;
+                    }
+                }
+                this.midiBuffer = newBuffer;
+                if (positionBeats) {
+                    newBuffer.seek(positionBeats, 'beats');
+                }
+                newBuffer.start();
+            }).catch(error => {
+                console.error('Tempo change error', error);
+            });
+        },
+        handlePlaybackEnded: function () {
+            this.midiBuffer = null;
+            if (this.looping) {
+                this.startPlaying();
+                return;
+            }
+            this.paused = true;
         },
         stopPlaying: function () {
             this.paused = true;
             if (this.midiBuffer) {
+                // ABCJS stop() fires onEnded — clear it so loop mode doesn't
+                // restart, and null the buffer ourselves.
+                this.midiBuffer.onEnded = null;
                 this.midiBuffer.stop();
-                this.pause = false;
+                this.midiBuffer = null;
             }
         },
         goFullScreen: function () {
@@ -223,5 +322,17 @@ export default {
 
 .abcControls {
     min-width: 0 !important;
+}
+
+.tempoRow {
+    max-width: 320px;
+    margin-left: auto;
+    margin-right: auto;
+}
+
+.tempoLabel {
+    min-width: 3em;
+    text-align: right;
+    font-size: 0.85em;
 }
 </style>


### PR DESCRIPTION
Hi,

Here is a MR for the tempo slider, i also made the buttons somewhat smaller, very very big on my display. Added looping also, good for exercising..




AI Comment:

splitting the earlier combined branch into focused PRs as requested. This is the **tune playback controls** piece. No backend/Rust changes, no scoring changes, no data changes — it's entirely in `app/src/components/AbcDisplay.vue`.

## What this adds

- **Tempo slider** (25%–200% of the tune's notated tempo). It scales `millisecondsPerMeasure` when playback starts.
- **Loop toggle** — when on, the tune restarts automatically when it reaches the end.
- **Seamless tempo change while playing** — dragging the slider mid-tune doesn't stop/restart playback. It primes a second synth at the new tempo in the background, then swaps to it at the *same musical position* (elapsed seconds converted to beats), so there's no audible gap.

## Notes on the implementation

- The `AudioContext` is now **reused** across plays instead of recreated each time. iOS disallows creating multiple `AudioContext`s, and the background re-prime for the tempo change needs to share the currently-playing context.
- `onEnded` is now passed **nested under `options.options`** — ABCJS reads it as `params = options.options` then `params.onEnded`. It's cleared on pause/stop so loop mode only restarts on a genuine natural end, not when the user pauses or stops. (This also fixes a latent `this.pause = false` typo in the old `stopPlaying`, which set a non-existent property instead of `this.paused`.)


## Testing

- `npm run build` passes clean.
- ESLint passes clean on the changed file.
- Manually verified play / pause / resume / stop, loop on/off, and dragging the tempo slider both while stopped and while playing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)